### PR TITLE
method to predict on words

### DIFF
--- a/include/cfasttext.h
+++ b/include/cfasttext.h
@@ -124,7 +124,7 @@ CFASTTEXT_API bool cft_fasttext_is_quant(fasttext_t* handle);
 CFASTTEXT_API void cft_fasttext_load_vectors(fasttext_t* handle, const char* filename, char** errptr);
 CFASTTEXT_API void cft_fasttext_train(fasttext_t* handle, fasttext_args_t* args, char** errptr);
 CFASTTEXT_API fasttext_predictions_t* cft_fasttext_predict(fasttext_t* handle, const char* text, int32_t k, float threshold);
-CFASTTEXT_API fasttext_predictions_t* cft_fasttext_predict_on_words(fasttext_t* handle, fasttext_words_t* words, int32_t k, float threshold)
+CFASTTEXT_API fasttext_predictions_t* cft_fasttext_predict_on_words(fasttext_t* handle, fasttext_words_t* words, int32_t k, float threshold);
 CFASTTEXT_API void cft_fasttext_predictions_free(fasttext_predictions_t* predictions);
 CFASTTEXT_API void cft_fasttext_quantize(fasttext_t* handle, fasttext_args_t* args, char** errptr);
 CFASTTEXT_API fasttext_tokens_t* cft_fasttext_tokenize(fasttext_t* handle, const char* text);

--- a/include/cfasttext.h
+++ b/include/cfasttext.h
@@ -31,6 +31,10 @@ typedef struct {
     char** tokens;
     size_t length;
 } fasttext_tokens_t;
+typedef struct {
+    int32_t* words;
+    size_t length;
+} fasttext_words_t;
 
 typedef enum {
     MODEL_CBOW = 1,
@@ -120,6 +124,7 @@ CFASTTEXT_API bool cft_fasttext_is_quant(fasttext_t* handle);
 CFASTTEXT_API void cft_fasttext_load_vectors(fasttext_t* handle, const char* filename, char** errptr);
 CFASTTEXT_API void cft_fasttext_train(fasttext_t* handle, fasttext_args_t* args, char** errptr);
 CFASTTEXT_API fasttext_predictions_t* cft_fasttext_predict(fasttext_t* handle, const char* text, int32_t k, float threshold);
+CFASTTEXT_API fasttext_predictions_t* cft_fasttext_predict_on_words(fasttext_t* handle, fasttext_words_t* words, int32_t k, float threshold)
 CFASTTEXT_API void cft_fasttext_predictions_free(fasttext_predictions_t* predictions);
 CFASTTEXT_API void cft_fasttext_quantize(fasttext_t* handle, fasttext_args_t* args, char** errptr);
 CFASTTEXT_API fasttext_tokens_t* cft_fasttext_tokenize(fasttext_t* handle, const char* text);


### PR DESCRIPTION
Fasttext has very basic tokenizer and that's why we use external one. At the moment [fasttext-rs](https://github.com/messense/fasttext-rs) doesn't provide interface to submit words instead of sentence.
Would be useful to have that method  as core fastext library does provide it.